### PR TITLE
Describe how to run tests, fix encodings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ sepadd -- SEPA Direct Debit XML
 
 This is a python implementation to generate SEPA direct debit XML files.
 
-For now, this is basically a properly packaged, python 3 tested version 
+For now, this is basically a properly packaged, python 3 tested version
 of the `PySepaDD`_ implementation that was released by The Congressus under the MIT license.
 Thanks for your work!
 
@@ -59,6 +59,15 @@ Example:
     sepa.add_payment(payment)
 
     print(sepa.export())
+
+
+Development
+-----------
+
+To run the included tests::
+
+    pip install -r requirements_dev.txt
+    py.test tests
 
 
 Credits and License

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,11 @@ To run the included tests::
     pip install -r requirements_dev.txt
     py.test tests
 
+To automatically sort your Imports as required by CI::
+
+    pip install isort
+    isort -rc .
+
 
 Credits and License
 -------------------

--- a/tests/test_escaped.py
+++ b/tests/test_escaped.py
@@ -1,12 +1,11 @@
-# encoding: utf-8
-
 import datetime
 
 import pytest
 
 from sepadd import SepaDD
 
-from .utils import clean_ids, validate_xml
+from .utils import clean_ids
+from .utils import validate_xml
 
 
 @pytest.fixture
@@ -201,7 +200,7 @@ def test_two_debits(sdd):
         "collection_date": datetime.date.today(),
         "mandate_id": "1234",
         "mandate_date": datetime.date.today(),
-        "description": u"Testgrüße <html>"
+        "description": "Testgrüße <html>"
     }
 
     sdd.add_payment(payment1)

--- a/tests/test_escaped.py
+++ b/tests/test_escaped.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 import pytest
@@ -199,7 +201,7 @@ def test_two_debits(sdd):
         "collection_date": datetime.date.today(),
         "mandate_id": "1234",
         "mandate_date": datetime.date.today(),
-        "description": "Testgrüße <html>"
+        "description": u"Testgrüße <html>"
     }
 
     sdd.add_payment(payment1)


### PR DESCRIPTION
Tests failed on my machine (Mac OS 10.13, vanilla Python 2.7) with ` SyntaxError: Non-ASCII character '\xc3' in file /Users/md/github/python-sepadd/tests/test_escaped.py on line 202, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`

I assume other Developers have defined a default encoding on their machine. This fix defines an encoding and uses a Unicode String for non ASCII Strings in the tests.